### PR TITLE
fix: respect RUST_LOG environment variable for log level filtering

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,9 @@ use crate::types::ChainPusher;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt().init();
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
     dotenvy::dotenv().ok();
     let args = Args::parse();
     let private_key = get_private_key(args.private_key);


### PR DESCRIPTION
## Summary
- Modified tracing subscriber initialization to use `EnvFilter::from_default_env()`
- Allows `RUST_LOG` environment variable to control log level filtering
- Fixes issue where INFO logs were always shown regardless of RUST_LOG setting

## Test plan
- Set `export RUST_LOG="warn"` and verify only WARN/ERROR logs are displayed
- Test with other log levels (debug, info, error) to ensure proper filtering