### PR TITLE
fix: log transaction errors in StorkChainPusher::send_price_updates

### DIFF
--- a/src/stork/chain_pusher.rs
+++ b/src/stork/chain_pusher.rs
@@ -9,7 +9,7 @@ use solana_sdk::{
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
-use tracing::info;
+use tracing::{error, info};
 
 pub struct StorkChainPusher {
     rpc_client: RpcClient,
@@ -73,8 +73,15 @@ impl StorkChainPusher {
         };
         let rpc_client = self.rpc_client.get_inner_client().clone();
         tokio::spawn(async move {
-            if let Ok(signature) = rpc_client.send_transaction_with_config(&tx, options).await {
-                info!("\nTransaction sent: {}", signature);
+            // Previously used `if let Ok(...)` which silently discarded all
+            // transaction errors. Use a match so failures are always logged.
+            match rpc_client.send_transaction_with_config(&tx, options).await {
+                Ok(signature) => {
+                    info!("\nTransaction sent: {}", signature);
+                }
+                Err(err) => {
+                    error!("\nTransaction error: {}", err);
+                }
             }
         });
         Ok(())


### PR DESCRIPTION
## Summary

Fixes silently-discarded Solana transaction errors in `StorkChainPusher::send_price_updates` (`src/stork/chain_pusher.rs`).

---

### Bug — `if let Ok` discards every transaction error with zero logging

```rust
// Before
tokio::spawn(async move {
    if let Ok(signature) = rpc_client
        .send_transaction_with_config(&tx, options).await
    {
        info!("
Transaction sent: {}", signature);
    }
    // Err variant: silently dropped
});
```

For a real-time pricing oracle, every call to `process_update` dispatches a Solana transaction that writes the latest price on-chain. If that transaction fails (RPC error, blockhash expiry, fee payer balance issues, etc.), the failure is completely invisible — no log line, no metric, no alert. Operators only discover the problem by noticing stale on-chain data, potentially long after the issue began.

This inconsistency is especially notable because the sibling `PythChainPusher` already uses a `match` arm and logs the error (albeit at the wrong level — see companion PR).

---

### Fix

```rust
// After
tokio::spawn(async move {
    match rpc_client
        .send_transaction_with_config(&tx, options).await
    {
        Ok(signature) => {
            info!("
Transaction sent: {}", signature);
        }
        Err(err) => {
            error!("
Transaction error: {}", err);
        }
    }
});
```

Adds `error` to the `tracing` import and uses it for the `Err` arm so the failure is visible at the correct severity level.

---

### Impact
- Severity: **Critical** — price-feed transaction failures are completely invisible, leading to silent stale prices
- Affected component: `real-time-pricing-oracle / src/stork/chain_pusher.rs`