### PR TITLE
fix: log price-feed transaction errors at error! level in PythChainPusher

### DIFF
--- a/src/pyth_lazer/chain_pusher.rs
+++ b/src/pyth_lazer/chain_pusher.rs
@@ -10,7 +10,7 @@ use solana_sdk::{
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
-use tracing::info;
+use tracing::{error, info};
 
 pub struct PythChainPusher {
     rpc_client: RpcClient,
@@ -110,7 +110,9 @@ impl PythChainPusher {
                     info!("\nTransaction sent: {}", signature);
                 }
                 Err(err) => {
-                    info!("\nTransaction error: {}", err);
+                    // Previously logged at `info!` level, causing monitoring
+                    // systems to miss price-feed transaction failures entirely.
+                    error!("\nTransaction error: {}", err);
                 }
             }
         });


### PR DESCRIPTION
## Summary

Fixes incorrect log severity for Solana transaction errors in `PythChainPusher::send_price_updates` (`src/pyth_lazer/chain_pusher.rs`).

---

### Bug — Transaction errors logged at `info!` instead of `error!`

```rust
// Before
match rpc_client.send_transaction_with_config(&tx, options).await {
    Ok(signature) => { info!("
Transaction sent: {}", signature); }
    Err(err)      => { info!("
Transaction error: {}", err); }  // ← wrong level
}
```

Both the success path and the error path use `info!`. In any standard observability setup (log-level filtering, alerting on ERROR/WARN, dashboards, PagerDuty integrations) this means price-feed transaction failures are indistinguishable from normal informational messages. Operators watching error-rate dashboards will see zero errors even as the oracle silently fails to update on-chain prices.

This is particularly harmful for a real-time pricing oracle where stale prices can affect downstream DeFi protocols.

---

### Fix

```rust
// After
Err(err) => {
    // Changed from info! to error! so monitoring pipelines are alerted
    error!("
Transaction error: {}", err);
}
```

`error` is added to the `tracing` import alongside the existing `info`.

---

### Impact
- Severity: **High** — transaction failures are masked as INFO, preventing automated alerting and delayed incident response
- Affected component: `real-time-pricing-oracle / src/pyth_lazer/chain_pusher.rs`