### PR TITLE
fix: replace fragile URL-substring provider detection with explicit --provider flag

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -25,6 +25,18 @@ impl std::fmt::Display for ChannelType {
     }
 }
 
+/// The oracle provider / price-feed protocol to use.
+///
+/// Previously the binary detected the provider by checking whether any WebSocket
+/// URL contained the substring `"stork"`. That heuristic silently breaks when
+/// URL hostnames change or when a Pyth URL happens to contain the word "stork".
+/// Use `--provider` to make the selection explicit and deterministic.
+#[derive(Debug, Clone, ValueEnum, PartialEq)]
+pub enum Provider {
+    Stork,
+    Pyth,
+}
+
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
@@ -57,6 +69,14 @@ pub struct Args {
         help = "Channel of the WebSocket to subscribe to (real_time, fixed_rate@1ms, fixed_rate@50ms, fixed_rate@200ms)"
     )]
     pub channel: Option<ChannelType>,
+    #[arg(
+        long,
+        help = "Price-feed provider to use: stork or pyth. Defaults to pyth. \
+                Previously the provider was inferred by checking whether the WebSocket URL \
+                contained the substring 'stork', which is fragile. Prefer setting this flag explicitly.",
+        value_enum
+    )]
+    pub provider: Option<Provider>,
 }
 
 pub fn get_ws_urls(cli_url: Option<String>, cli_urls: Vec<String>) -> Vec<String> {
@@ -139,4 +159,38 @@ pub fn get_channel(cli_channel: Option<ChannelType>) -> String {
         .ok()
         .or(cli_channel.map(|c| c.to_string()))
         .unwrap_or_else(|| ChannelType::FixedRate50ms.to_string())
+}
+
+/// Determine the oracle provider from the `--provider` flag, the
+/// `ORACLE_PROVIDER` environment variable, or — as a deprecated last resort —
+/// the URL-substring heuristic that was previously hard-coded in `main`.
+pub fn get_provider(cli_provider: Option<Provider>, ws_urls: &[String]) -> Provider {
+    // Explicit CLI flag takes highest priority.
+    if let Some(p) = cli_provider {
+        return p;
+    }
+
+    // Environment variable is second priority.
+    if let Ok(env_val) = std::env::var("ORACLE_PROVIDER") {
+        match env_val.to_lowercase().as_str() {
+            "stork" => return Provider::Stork,
+            "pyth" => return Provider::Pyth,
+            other => warn!(
+                "Unknown ORACLE_PROVIDER value '{}'; falling back to URL detection",
+                other
+            ),
+        }
+    }
+
+    // Last resort: replicate the old URL heuristic so existing deployments
+    // that rely on it continue to work, but emit a deprecation warning.
+    if ws_urls.iter().any(|url| url.contains("stork")) {
+        warn!(
+            "Provider inferred from WebSocket URL containing 'stork'. \
+             This heuristic is fragile; set --provider=stork or ORACLE_PROVIDER=stork explicitly."
+        );
+        Provider::Stork
+    } else {
+        Provider::Pyth
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,8 @@ use tracing::{debug, error, info, warn};
 use url::Url;
 
 use crate::args::{
-    get_auth_header, get_channel, get_price_feeds, get_private_key, get_solana_cluster,
-    get_ws_urls, Args,
+    get_auth_header, get_channel, get_price_feeds, get_private_key, get_provider,
+    get_solana_cluster, get_ws_urls, Args, Provider,
 };
 use crate::pyth_lazer::chain_pusher::PythChainPusher;
 use crate::stork::chain_pusher::StorkChainPusher;
@@ -48,16 +48,21 @@ async fn main() {
     let cluster_url = get_solana_cluster(args.cluster);
     let price_feeds = get_price_feeds(args.price_feeds);
     let channel = get_channel(args.channel);
+    let provider = get_provider(args.provider, &ws_urls);
 
     let payer = Keypair::from_base58_string(&private_key);
     info!(wallet_pubkey = ?payer.pubkey(), "Identity initialized");
 
     let tls_connector = TlsConnector::from(NativeTlsConnector::new().expect("Failed to create TLS connector"));
 
-    let chain_pusher: Arc<dyn ChainPusher> = if ws_urls.iter().any(|url| url.contains("stork")) {
-        Arc::new(StorkChainPusher::new(&cluster_url, payer).await)
-    } else {
-        Arc::new(PythChainPusher::new(&cluster_url, payer).await)
+    // Previously the provider was selected by checking whether any WebSocket
+    // URL contained the substring "stork", which silently breaks when URLs
+    // change or a Pyth URL happens to include that word. The provider is now
+    // determined explicitly via `--provider` / `ORACLE_PROVIDER` (with the old
+    // heuristic as a deprecated fallback inside `get_provider`).
+    let chain_pusher: Arc<dyn ChainPusher> = match provider {
+        Provider::Stork => Arc::new(StorkChainPusher::new(&cluster_url, payer).await),
+        Provider::Pyth => Arc::new(PythChainPusher::new(&cluster_url, payer).await),
     };
 
     loop {


### PR DESCRIPTION
## Summary

Replaces the fragile WebSocket URL substring heuristic used to select between `StorkChainPusher` and `PythChainPusher` with a proper `--provider` CLI flag and `ORACLE_PROVIDER` environment variable.

---

### Bug — Provider selected by checking `url.contains("stork")`

```rust
// Before (main.rs)
let chain_pusher: Arc<dyn ChainPusher> =
    if ws_urls.iter().any(|url| url.contains("stork")) {
        Arc::new(StorkChainPusher::new(&cluster_url, payer).await)
    } else {
        Arc::new(PythChainPusher::new(&cluster_url, payer).await)
    };
```

This heuristic breaks silently in several realistic scenarios:

1. **Domain change / CDN alias** — if Stork changes its WebSocket hostname to one that no longer contains the word `stork`, the binary silently starts using `PythChainPusher`, which parses the message format incorrectly and fails to submit any price updates.
2. **Pyth URL with the word stork** — unlikely but possible via proxy URLs or internal routing aliases, causing the opposite misidentification.
3. **No override mechanism** — there is no way to force the provider selection without changing the URL itself.

In both failure modes the oracle silently uses the wrong parser, `process_update` returns errors for every message, and on-chain prices go stale with no clear diagnostic.

---

### Fix

Adds a `Provider` enum (`Stork` | `Pyth`) to `args.rs` with:
- A `--provider` CLI flag (highest priority)
- An `ORACLE_PROVIDER` environment variable (second priority)
- The old URL heuristic as a deprecated last resort that emits a `warn!()` telling operators to migrate

```rust
// After (main.rs)
let provider = get_provider(args.provider, &ws_urls);
let chain_pusher: Arc<dyn ChainPusher> = match provider {
    Provider::Stork => Arc::new(StorkChainPusher::new(&cluster_url, payer).await),
    Provider::Pyth  => Arc::new(PythChainPusher::new(&cluster_url, payer).await),
};
```

Existing deployments that rely on the URL heuristic continue to work without changes; the new flag is optional. Setting it removes the deprecation warning and makes the selection deterministic.

---

### Files changed
- `src/args.rs` — adds `Provider` enum, `provider` field to `Args`, and `get_provider()` helper
- `src/main.rs` — uses `get_provider()` and a `match` instead of the URL-contains chain

### Impact
- Severity: **High** — silent misidentification of provider causes oracle to stop publishing prices with no error signal
- Affected components: `real-time-pricing-oracle / src/args.rs`, `src/main.rs`