### PR TITLE
fix: use oracle publish timestamp

### DIFF
--- a/program/ephemeral-oracle/programs/ephemeral-oracle/src/lib.rs
+++ b/program/ephemeral-oracle/programs/ephemeral-oracle/src/lib.rs
@@ -71,7 +71,7 @@ pub mod ephemeral_oracle {
         price_feed.price_message = PriceFeedMessage {
             prev_publish_time: prev.publish_time,
             price: new_price,
-            publish_time: clock.unix_timestamp,
+            publish_time: (update_data.temporal_numeric_value.timestamp_ns / 1_000_000_000) as i64,
             ..prev
         };
         price_feed.verification_level = VerificationLevel::Full;


### PR DESCRIPTION
## Summary

- use the oracle-provided timestamp for price feed publication time
- convert the timestamp from nanoseconds to seconds as expected by the Pyth price message
- keep the posted slot tied to transaction processing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Price feed updates now use the timestamp provided with the source data.
  * This improves timestamp accuracy and consistency for published price feed messages, especially when processing data that was generated earlier than the current system time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->